### PR TITLE
[Fix] Typos on `ES` corpus

### DIFF
--- a/lang-es/corpus.txt
+++ b/lang-es/corpus.txt
@@ -460,7 +460,7 @@ los que residen en su Consejo, certifico y doy fe que, habiendo visto por
 los señores dél un libro intitulado El ingenioso hidalgo de la Mancha,
 compuesto por Miguel de Cervantes Saavedra, tasaron cada pliego del dicho
 libro a tres maravedís y medio; el cual tiene ochenta y tres pliegos, que
-al dicho precio monta el dicho libro docientos y noventa maravedís y medio,
+al dicho precio monta el dicho libro doscientos y noventa maravedís y medio,
 en que se ha de vender en papel; y dieron licencia para que a este precio
 se pueda vender, y mandaron que esta tasa se ponga al principio del dicho
 libro, y no se pueda vender sin ella. Y, para que dello conste, di la
@@ -4472,7 +4472,7 @@ brazo, han subido a los altos grados que he contado; y estos mesmos se
 vieron antes y después en diversas calamidades y miserias. Porque el
 valeroso Amadís de Gaula se vio en poder de su mortal enemigo Arcaláus el
 encantador, de quien se tiene por averiguado que le dio, teniéndole
-preso, más de docientos azotes con las riendas de su caballo, atado a una
+preso, más de doscientos azotes con las riendas de su caballo, atado a una
 coluna de un patio. Y aun hay un autor secreto, y de no poco crédito, que
 dice que, habiendo cogido al Caballero del Febo con una cierta trampa que
 se le hundió debajo de los pies, en un cierto castillo, y al caer, se halló
@@ -5819,7 +5819,7 @@ Parecióle bien el consejo a don Quijote, y, tomando de la rienda a
 Rocinante, y Sancho del cabestro a su asno, después de haber puesto sobre
 él los relieves que de la cena quedaron, comenzaron a caminar por el prado
 arriba a tiento, porque la escuridad de la noche no les dejaba ver cosa
-alguna; mas, no hubieron andado docientos pasos, cuando llegó a sus oídos
+alguna; mas, no hubieron andado doscientos pasos, cuando llegó a sus oídos
 un grande ruido de agua, como que de algunos grandes y levantados riscos se
 despeñaba. Alegróles el ruido en gran manera, y, parándose a escuchar hacia
 qué parte sonaba, oyeron a deshora otro estruendo que les aguó el contento
@@ -6776,7 +6776,7 @@ Mas una de las guardas le dijo:
 — Señor caballero, cantar en el ansia se dice, entre esta gente non santa,
 confesar en el tormento. A este pecador le dieron tormento y confesó su
 delito, que era ser cuatrero, que es ser ladrón de bestias, y, por haber
-confesado, le condenaron por seis años a galeras, amén de docientos azotes
+confesado, le condenaron por seis años a galeras, amén de doscientos azotes
 que ya lleva en las espaldas. Y va siempre pensativo y triste, porque los
 demás ladrones que allá quedan y aquí van le maltratan y aniquilan, y
 escarnecen y tienen en poco, porque confesó y no tuvo ánimo de decir nones.
@@ -6911,8 +6911,8 @@ vidas ajenas; y si la mía quiere saber, sepa que yo soy Ginés de Pasamonte,
 cuya vida está escrita por estos pulgares.
 
 — Dice verdad —dijo el comisario—: que él mesmo ha escrito su historia, que
-no hay más, y deja empeñado el libro en la cárcel en docientos reales.
-— Y le pienso quitar —dijo Ginés—, si quedara en docientos ducados.
+no hay más, y deja empeñado el libro en la cárcel en doscientos reales.
+— Y le pienso quitar —dijo Ginés—, si quedara en doscientos ducados.
 — ¿Tan bueno es? —dijo don Quijote.
 
 — Es tan bueno —respondió Ginés— que mal año para Lazarillo de Tormes y para
@@ -14225,7 +14225,7 @@ valían otro tanto. Las perlas eran en gran cantidad y muy buenas, porque la
 mayor gala y bizarría de las moras es adornarse de ricas perlas y aljófar,
 y así, hay más perlas y aljófar entre moros que entre todas las demás
 naciones; y el padre de Zoraida tenía fama de tener muchas y de las mejores
-que en Argel había, y de tener asimismo más de docientos mil escudos
+que en Argel había, y de tener asimismo más de doscientos mil escudos
 españoles, de todo lo cual era señora esta que ahora lo es mía. Si con todo
 este adorno podía venir entonces hermosa, o no, por las reliquias que le
 han quedado en tantos trabajos se podrá conjeturar cuál debía de ser en las
@@ -17997,7 +17997,7 @@ que residen en su Consejo, doy fe que, habiéndose visto por los señores dél
 un libro que compuso Miguel de Cervantes Saavedra, intitulado Don Quijote
 de la Mancha, Segunda parte, que con licencia de Su Majestad fue impreso,
 le tasaron a cuatro maravedís cada pliego en papel, el cual tiene setenta y
-tres pliegos, que al dicho respeto suma y monta docientos y noventa y dos
+tres pliegos, que al dicho respeto suma y monta doscientos y noventa y dos
 maravedís, y mandaron que esta tasa se ponga al principio de cada volumen
 del dicho libro, para que se sepa y entienda lo que por él se ha de pedir y
 llevar, sin que se exceda en ello en manera alguna, como consta y parece
@@ -18442,7 +18442,7 @@ todos los caballeros andantes que vagan por España; que, aunque no viniesen
 sino media docena, tal podría venir entre ellos, que solo bastase a
 destruir toda la potestad del Turco? Esténme vuestras mercedes atentos, y
 vayan conmigo. ¿Por ventura es cosa nueva deshacer un solo caballero
-andante un ejército de docientos mil hombres, como si todos juntos tuvieran
+andante un ejército de doscientos mil hombres, como si todos juntos tuvieran
 una sola garganta, o fueran hechos de alfenique? Si no, díganme: ¿cuántas
 historias están llenas destas maravillas? ¡Había, en hora mala para mí, que
 no quiero decir para otro, de vivir hoy el famoso don Belianís, o alguno de
@@ -20384,7 +20384,7 @@ se descubre la debe de hacer el palacio de Dulcinea.
 veré con los ojos y lo tocaré con las manos, y así lo creeré yo como creer
 que es ahora de día.
 
-Guió don Quijote, y, habiendo andado como docientos pasos, dio con el bulto
+Guió don Quijote, y, habiendo andado como doscientos pasos, dio con el bulto
 que hacía la sombra, y vio una gran torre, y luego conoció que el tal
 edificio no era alcázar, sino la iglesia principal del pueblo. Y dijo:
 
@@ -25204,7 +25204,7 @@ sus hermosos cabellos, como si ellos tuvieran la culpa del maleficio. Miren
 también cómo aquel grave moro que está en aquellos corredores es el rey
 Marsilio de Sansueña; el cual, por haber visto la insolencia del moro,
 puesto que era un pariente y gran privado suyo, le mandó luego prender, y
-que le den docientos azotes, llevándole por las calles acostumbradas de la
+que le den doscientos azotes, llevándole por las calles acostumbradas de la
 ciudad,
 
 con chilladores delante
@@ -25445,7 +25445,7 @@ que luego lo desembolsó Sancho, pidió maese Pedro dos reales por el trabajo
 de tomar el mono.
 
 — Dáselos, Sancho —dijo don Quijote—, no para tomar el mono, sino la mona; y
-docientos diera yo ahora en albricias a quien me dijera con certidumbre que
+doscientos diera yo ahora en albricias a quien me dijera con certidumbre que
 la señora doña Melisendra y el señor don Gaiferos estaban ya en Francia y
 entre los suyos.
 
@@ -25544,7 +25544,7 @@ cosa digna de ponerse en escritura, hasta que al tercero, al subir de una
 loma, oyó un gran rumor de atambores, de trompetas y arcabuces. Al
 principio pensó que algún tercio de soldados pasaba por aquella parte, y
 por verlos picó a Rocinante y subió la loma arriba; y cuando estuvo en la
-cumbre, vio al pie della, a su parecer, más de docientos hombres armados de
+cumbre, vio al pie della, a su parecer, más de doscientos hombres armados de
 diferentes suertes de armas, como si dijésemos lanzones, ballestas,
 partesanas, alabardas y picas, y algunos arcabuces, y muchas rodelas. Bajó
 del recuesto y acercóse al escuadrón, tanto, que distintamente vio las
@@ -30078,7 +30078,7 @@ esforzada y no forzada:
 esta bolsa le mostrárades, y aun la mitad menos, para defender vuestro
 cuerpo, las fuerzas de Hércules no os hicieran fuerza. Andad con Dios, y
 mucho de enhoramala, y no paréis en toda esta ínsula ni en seis leguas a la
-redonda, so pena de docientos azotes. ¡Andad luego digo, churrillera,
+redonda, so pena de doscientos azotes. ¡Andad luego digo, churrillera,
 desvergonzada y embaidora!
 
 Espantóse la mujer y fuese cabizbaja y mal contenta, y el gobernador dijo
@@ -32632,14 +32632,14 @@ registrar.
 — Bien puede ser eso —replicó Ricote—, pero yo sé, Sancho, que no tocaron a
 mi encierro, porque yo no les descubrí dónde estaba, temeroso de algún
 desmán; y así, si tú, Sancho, quieres venir conmigo y ayudarme a sacarlo y
-a encubrirlo, yo te daré docientos escudos, con que podrás remediar tus
+a encubrirlo, yo te daré doscientos escudos, con que podrás remediar tus
 necesidades, que ya sabes que sé yo que las tienes muchas.
 
 — Yo lo hiciera —respondió Sancho—, pero no soy nada codicioso; que, a
 serlo, un oficio dejé yo esta mañana de las manos, donde pudiera hacer las
 paredes de mi casa de oro, y comer antes de seis meses en platos de plata;
 y, así por esto como por parecerme haría traición a mi rey en dar favor a
-sus enemigos, no fuera contigo, si como me prometes docientos escudos, me
+sus enemigos, no fuera contigo, si como me prometes doscientos escudos, me
 dieras aquí de contado cuatrocientos.
 
 — Y ¿qué oficio es el que has dejado, Sancho? —preguntó Ricote.
@@ -33189,7 +33189,7 @@ armado en la plaza del castillo. Mirábanle de los corredores toda la gente
 del castillo, y asimismo los duques salieron a verle. Estaba Sancho sobre
 su rucio, con sus alforjas, maleta y repuesto, contentísimo, porque el
 mayordomo del duque, el que fue la Trifaldi, le había dado un bolsico con
-docientos escudos de oro, para suplir los menesteres del camino, y esto aún
+doscientos escudos de oro, para suplir los menesteres del camino, y esto aún
 no lo sabía don Quijote.
 
 Estando, como queda dicho, mirándole todos, a deshora, entre las otras
@@ -33333,7 +33333,7 @@ aquél a quien el cielo dio un pedazo de pan, sin que le quede obligación de
 agradecerlo a otro que al mismo cielo!
 
 — Con todo eso —dijo Sancho— que vuesa merced me ha dicho, no es bien que se
-quede sin agradecimiento de nuestra parte docientos escudos de oro que en
+quede sin agradecimiento de nuestra parte doscientos escudos de oro que en
 una bolsilla me dio el mayordomo del duque, que como píctima y confortativo
 la llevo puesta sobre el corazón, para lo que se ofreciere; que no siempre
 hemos de hallar castillos donde nos regalen, que tal vez toparemos con
@@ -34422,7 +34422,7 @@ eran y adónde iban, y qué dinero llevaban. Uno dellos le respondió:
 — Señor, nosotros somos dos capitanes de infantería española; tenemos
 nuestras compañías en Nápoles y vamos a embarcarnos en cuatro galeras, que
 dicen están en Barcelona con orden de pasar a Sicilia; llevamos hasta
-docientos o trecientos escudos, con que, a nuestro parecer, vamos ricos y
+doscientos o trecientos escudos, con que, a nuestro parecer, vamos ricos y
 contentos, pues la estrecheza ordinaria de los soldados no permite mayores
 tesoros.
 
@@ -38408,7 +38408,7 @@ clases más altas, si que también en el pueblo, de cuyas aptitudes logró
 obtener, el connotado maestro de música, Don José Antonio Gaudier,
 catalán, alumnos de mérito, que como los Nadal, Ramírez, Freyre,
 Casanova, Defilló, Brito, Mesorana y otros, ocuparon, ya como
-dilettantes, ya como profesionales, puestos de honor artístico. Todos
+diletantes, ya como profesionales, puestos de honor artístico. Todos
 los hijos del Sr. Gaudier poseyeron conocimientos no superficiales de
 música, aunque no los utilizaron como profesión por haberles podido dar
 su Sr. padre, carreras literarias o científicas, cosa imposible hoy para
@@ -38655,7 +38655,7 @@ otros amateurs del arte, también de título y posición económica
 desahogada, que allí fueron a ejercer sus profesiones.
 
 Entre éstos figuraba el doctor Don Martín Corchado, que poseía y
-cultivaba, como dilettante, una hermosa voz de tenor, Don Olimpio Otero,
+cultivaba, como diletante, una hermosa voz de tenor, Don Olimpio Otero,
 persona cultísima y de gran influencia en la ciudad del Sur, y otros
 tantos, como los Marín, Biaggi, Cabrera, Salazar y otros más, que fueron
 los iniciadores, por decirlo así, del renacimiento social, intelectual,
@@ -39082,7 +39082,7 @@ agricultura el ciclón del 8 de agosto de 1899 conocido por el nombre de
 Ciclón de San Ciriaco, paralizó por 3 o 4 años las visitas frecuentes
 que hacían a la isla diversas compañías de zarzuela y ópera. Con tal
 motivo, y con el fin de hacer amena la vida capitaleña, varios
-dilettantes organizaron la sociedad, denominada Gira Artística, para
+diletantes organizaron la sociedad, denominada Gira Artística, para
 poner en escena obras dramáticas y líricas del género chico. En la
 sección lírica figuraban, bajo la dirección del maestro concertador Don
 Joaquín Burset, joven humacaeño que había hecho sus estudios musicales
@@ -39178,7 +39178,7 @@ constituyó una nota de progreso artístico.
 
 También, hace más de tres años, viene celebrando mensualmente selectas
 audiciones musicales, otra sociedad denominada Club Armónico,
-integrada por buenos artistas, en su mayor parte dilettantes, que con
+integrada por buenos artistas, en su mayor parte diletantes, que con
 una constancia digna de encomio y gran fervor artístico, se reunen todas
 las noches en el salón Apolo, para estudiar, minuciosamente, las obras
 que han de ser ejecutadas en el concierto mensual, prescrito por los
@@ -39273,7 +39273,7 @@ tan seductora e idealista danza portorriqueña.
 
 En los últimos dos lustros han visitado la Isla algunas compañías
 líricas de ópera, zarzuela y opereta de bastante mérito. La que
-contratara en Milán, el entusiasta dilettante, Américo Marín, ya
+contratara en Milán, el entusiasta diletante, Américo Marín, ya
 fallecido, fué conceptuada como de primer orden, pues no solamente
 estaba triplicado el cuarteto de voces principales, sino que los
 integraban artistas afamados como Di Bernardo, Paganelli, Regina Álvarez
@@ -42253,7 +42253,7 @@ Juan.
 
 BRUNO DE CAÑELLAS, Cecilia.--
 
-Calificada dilettante, meramente por practicar el canto como expansión
+Calificada diletante, meramente por practicar el canto como expansión
 del alma, por las condiciones de su voz y pura escuela de emisión que
 posee, el epíteto que, en verdad y justicia, le corresponde no es otro
 que el de artista.
@@ -42418,7 +42418,7 @@ Natural de San Juan, e hija del flautista don Manuel, con don Ramón
 Sarriera cursó los estudios del canto y piano. Su voz de soprano lírico,
 bien timbrada, aunque de mediano volumen, si hubiese sido educada con el
 rigor de la escuela europea, hubiera alcanzado altos prestigios en el
-género de la Zarzuela española. Como dilettante ha sido justamente
+género de la Zarzuela española. Como diletante ha sido justamente
 aplaudida en todos los actos públicos a que ha asistido. Su vis cómica
 en el género chico le proporcionó grandes triunfos sobre todo en
 Chateau Margaux, zarzuela en un acto que caracterizó a conciencia.
@@ -42537,7 +42537,7 @@ MORENO CALDERÓN, Teresina.
 Hija de don Antonio Moreno Santí y de doña Teresa Calderón, en cuyo
 hogar distinguido y durante algunos años reuníanse todos los miércoles
 por la noche, para hacer música además de su hermana Isabel, hoy
-viuda de Romero, pianista dilettante de gran ejecución y esmerado
+viuda de Romero, pianista diletante de gran ejecución y esmerado
 estilo, los profesores Toledo, Sarriera, Gómez Tizol, Dueño Colón,
 Julián Andino, y algunos otros, nació en el año 1880 nuestra
 biografiada.
@@ -42655,7 +42655,7 @@ formas de expresión, a la que hasta hoy no ha sido superada como soprano
 ligera.
 
 Isabelita Oller, cantó la parte de Anona en la ópera Guarionex. Su
-esposo Don Manuel Paniagua era también dilettante con voz de tenor y una
+esposo Don Manuel Paniagua era también diletante con voz de tenor y una
 gran cultura artística.
 
 
@@ -42788,7 +42788,7 @@ tono cultural de Lizzie cuya nota predominante es la modestia. La buena
 sociedad ponceña se congregaba en sus salones en los que no faltaban,
 atraídos por el Sol, satélites tan brillantes como el inolvidable Dr.
 Martín Corchado y Juarbe, la señora Amalia Arce de Otero, Gil de
-Taboada, dilettantes que poseían, en calidad y escuela, voces bellísimas
+Taboada, diletantes que poseían, en calidad y escuela, voces bellísimas
 de tenor, soprano y barítono, respectivamente. También fueron asíduos
 contertulios los maestros Tavárez y Forns. De esos inolvidables
 reuniones o noches de arte, en que reinaba la mayor armonía moral por
@@ -42824,7 +42824,7 @@ Nació en Ponce demostrando desde niña gran amor por el canto y notables
 aptitudes para la música.
 
 A los 7 años dió principio a los estudios del piano bajo la dirección de
-su señora madre, que fué una pianista dilettante muy notable. Más tarde
+su señora madre, que fué una pianista diletante muy notable. Más tarde
 con Lizzie Graham tomó lecciones de canto, quedando a los 15 años, bajo
 la exclusiva dirección, en ambos estudios, del que después ha sido su
 esposo, el connotado maestro Julio C. Arteaga.
@@ -43487,7 +43487,7 @@ BALSEIRO DÁVILA, Rafael.
 Nació en Arecibo el 24 de septiembre de 1867. De alto temperamento
 musical, a los 9 años empezó a estudiar el arte con el connotado
 pianista Heraclio Ramos, que también fué el maestro de Aurea Balseiro,
-hoy señora de Georgetti, y que es una pianista dilettante de esmerada
+hoy señora de Georgetti, y que es una pianista diletante de esmerada
 ejecución, delicado estilo y expresión ajustada a las obras que
 interpreta, aunque sumamente tímida para dejarse oir fuera del santuario
 de su hogar.
@@ -43512,7 +43512,7 @@ profesor de piano, hasta que su señor padre lo llevó a su escritorio
 agrícolo-comercial como jefe de la contabilidad, con residencia en
 Barceloneta.
 
-De profesional se transformó en dilettante, y en sus ratos de ocio
+De profesional se transformó en diletante, y en sus ratos de ocio
 empezó a verter al pentagrama las inspiraciones de su fantasía,
 netamente criolla.
 
@@ -44150,7 +44150,7 @@ vuelos, honrará dignamente su apellido, de gran abolengo artístico.
        *       *       *       *       *
 
 Al cerrar esta sección, consideramos justo citar los nombres de algunos
-dilettantes que con frecuencia han dado y dan a la publicidad las
+diletantes que con frecuencia han dado y dan a la publicidad las
 inspiraciones de su fantasía, en las que se encuentran ideas melódicas
 bien definidas, efluvios estéticos de sus temperamentos artísticos.
 
@@ -44190,7 +44190,7 @@ sido refrendados por juicios públicos y competentes, eliminando, para no
 ser difusos, a los que bajo otros aspectos hayan sido citados.
 
 Los relatos tendrán la amplitud de las referencias adquiridas,
-circunscribiendo la mención de los dilettantes a sus nombres,
+circunscribiendo la mención de los diletantes a sus nombres,
 instrumento en que han sobresalido, y, a ser posible, el nombre del
 preceptor o escuela de donde proceden.
 
@@ -44304,13 +44304,13 @@ Caguas.
 
 ALVARADO, Margarita.
 
-Pianista dilettante. Natural de Juana Díaz. Discípula de Manuel G.
+Pianista diletante. Natural de Juana Díaz. Discípula de Manuel G.
 Tavárez, quien le dedicara su renombrada danza Margarita.
 
 
 ARCE DE ASTOL, Sicila.
 
-Pianista dilettante. Nació en Ponce. Discípula del maestro Torns.
+Pianista diletante. Nació en Ponce. Discípula del maestro Torns.
 
 
 ARIAS, Mercedes.--Profesional.
@@ -44360,13 +44360,13 @@ para las intimidades del hogar. Es artista.
 
 BOBADILLA, Asunción.
 
-Pianista dilettante. Discípula de Don Fermín Toledo. Si no estamos mal
+Pianista diletante. Discípula de Don Fermín Toledo. Si no estamos mal
 informados, nació en San Juan.
 
 
 CAPARROS, Inocencia.
 
-Pianista dilettante, natural de San Juan, fué una de las mejores
+Pianista diletante, natural de San Juan, fué una de las mejores
 discípulas del señor Cabrizas.
 
 
@@ -44486,7 +44486,7 @@ diera en Madrid al señor Coronel.
 
 DOMÍNGUEZ, Lcdo. Celestino.
 
-Pianista dilettante. Natural y residente de Guayama.
+Pianista diletante. Natural y residente de Guayama.
 
 Sus estudios superiores los hizo fuera del país.
 
@@ -44512,7 +44512,7 @@ Ejerció influencia en el movimiento musical de la isla.
 
 DUEÑO Y DUEÑO, Dr. Manuel.
 
-Pianista dilettante. Natural de Bayamón. Con su padre Don Braulio
+Pianista diletante. Natural de Bayamón. Con su padre Don Braulio
 estudió música.
 
 Durante cursaba medicina amplió en los EE. UU. sus estudios del piano.
@@ -44520,7 +44520,7 @@ Durante cursaba medicina amplió en los EE. UU. sus estudios del piano.
 
 FRADERAS, Fidel.
 
-Natural de Maricao. Pianista dilettante. Hizo los estudios musicales en
+Natural de Maricao. Pianista diletante. Hizo los estudios musicales en
 Barcelona, España.
 
 
@@ -44563,7 +44563,7 @@ por la sociedad capitaleña.
 GARCÍA ARTÍGUEZ, Elifio.
 
 Guitarrista, natural de Naguabo. No podemos clasificarle ni como
-profesional ni como dilettante, porque dentro de la especialidad del
+profesional ni como diletante, porque dentro de la especialidad del
 instrumento en que tanto brilla, hasta ahora, que nosotros sepamos, no
 se ejerce en la isla ese ramo de la enseñanza musical; y, por su arte
 exquisito, rebasa los linderos de la heredad en que fructifica el
@@ -44655,13 +44655,13 @@ Actualmente ejerce como dentista en Arecibo.
 
 IRIARTE, Lola.
 
-Pianista dilettante, natural de San Juan. Fué una de las alumnas más
+Pianista diletante, natural de San Juan. Fué una de las alumnas más
 prestigiosas del señor Sarriera.
 
 
 LAGO, José María.
 
-Clarinetista dilettante de gran fama. Natural de Arecibo y discípulo de
+Clarinetista diletante de gran fama. Natural de Arecibo y discípulo de
 Juan Inés Ramos.
 
 
@@ -44687,13 +44687,13 @@ buenos discípulos. Murió en 1912.
 
 LÓPEZ GASTAMBIDE, Miguel.
 
-Pianista dilettante, natural de Añasco. Perfeccionó en Barcelona y con
+Pianista diletante, natural de Añasco. Perfeccionó en Barcelona y con
 sus distintos viajes por Europa los conocimientos adquiridos en la Isla.
 
 
 MANGUAL, Rafael.
 
-Flautista dilettante, natural de Mayagüez. Discípulo predilecto del
+Flautista diletante, natural de Mayagüez. Discípulo predilecto del
 Nene Freyre.
 
 
@@ -44740,7 +44740,7 @@ tocaba con el carácter de profesional.
 
 MEDINA DE VASCONI, María.
 
-Pianista dilettante, nacida en San Juan. La discípula más connotada de
+Pianista diletante, nacida en San Juan. La discípula más connotada de
 Don Fermín Toledo.
 
 
@@ -44788,7 +44788,7 @@ tierra nativa.
 
 MORALES, José Miguel.
 
-Pianista dilettante ponceño. En la perla del sur hizo sus estudios de
+Pianista diletante ponceño. En la perla del sur hizo sus estudios de
 piano que ha ampliado con sus frecuentes viajes a los centros musicales
 de Europa y EE. UU.
 
@@ -44808,7 +44808,7 @@ comercial a las fatigas del profesorado.
 
 NADAL, Blas.
 
-Connotado pianista dilettante. Natural de Mayagüez. Su educación
+Connotado pianista diletante. Natural de Mayagüez. Su educación
 artística la recibió en Europa.
 
 
@@ -44969,7 +44969,7 @@ desaparecida!
 
 PENEDO DE CUEVAS ZEQUEIRA, Elisa.
 
-Pianista dilettante. Natural de Fajardo. Desconocemos con quien adquirió
+Pianista diletante. Natural de Fajardo. Desconocemos con quien adquirió
 su brillante escuela. Interpreta con maestría.
 
 
@@ -45034,7 +45034,7 @@ triunfos, en el extranjero.
 
 RODRÍGUEZ SERRA, Lcdo. Manuel.
 
-Pianista dilettante. Nació en Sabana Grande. Los estudios superiores de
+Pianista diletante. Nació en Sabana Grande. Los estudios superiores de
 música y piano los hizo en el extranjero.
 
 
@@ -45074,7 +45074,7 @@ Es artista por estudio y por temperamento.
 
 SANTINI, Nicolás.
 
-Flautista dilettante. Natural, según referencias, de Barranquitas. Hizo
+Flautista diletante. Natural, según referencias, de Barranquitas. Hizo
 en Ponce sus estudios musicales.
 
 
@@ -45138,7 +45138,7 @@ la Habana, Cuba.
 
 SICARDÓ DE CASTAÑOS, Josefa.
 
-Pianista dilettante. Natural de San Juan. Discípula del señor Sarriera.
+Pianista diletante. Natural de San Juan. Discípula del señor Sarriera.
 Reside actualmente en Madrid.
 
 
@@ -45152,7 +45152,7 @@ Dirige orquestas y bandas, cultivando también la composición.
 
 SOLER, Gerardo.
 
-Pianista dilettante. Natural de San Juan. Discípulo meritísimo del señor
+Pianista diletante. Natural de San Juan. Discípulo meritísimo del señor
 Cabrizas.
 
 
@@ -45241,7 +45241,7 @@ reside en la Habana en donde goza de reputación y afectos.
 
 VAN RYHN, Margarita.
 
-Pianista dilettante natural de Carolina. Se graduó de maestra de piano
+Pianista diletante natural de Carolina. Se graduó de maestra de piano
 en St. Aloysius Academy, New Lexington, Ohio. Actualmente hace estudios
 de perfeccionamiento en la Academia de Alicia Sicardó. Tiene grandes
 condiciones para llegar a ser una excelente artista.


### PR DESCRIPTION
`dilettante`: means nothing -> `diletante`: [RAE](https://dle.rae.es/diletante)
`docientos`: means nothing -> `doscientos`: Number 200

Related to: https://github.com/aradzie/keybr.com/pull/177