### PR TITLE
[FIX] Typo on `ES` encantamiento

### DIFF
--- a/lang-es/corpus.txt
+++ b/lang-es/corpus.txt
@@ -1083,7 +1083,7 @@ En resolución, él se enfrascó tanto en su letura, que se le pasaban las
 noches leyendo de claro en claro, y los días de turbio en turbio; y así,
 del poco dormir y del mucho leer, se le secó el celebro, de manera que vino
 a perder el juicio. Llenósele la fantasía de todo aquello que leía en los
-libros, así de encantamentos como de pendencias, batallas, desafíos,
+libros, así de encantamientos como de pendencias, batallas, desafíos,
 heridas, requiebros, amores, tormentas y disparates imposibles; y
 asentósele de tal modo en la imaginación que era verdad toda aquella
 máquina de aquellas sonadas soñadas invenciones que leía, que para él no
@@ -2355,7 +2355,7 @@ ello; porque aquel bastardo de don Roldán me ha molido a palos con el
 tronco de una encina, y todo de envidia, porque ve que yo solo soy el
 opuesto de sus valentías. Mas no me llamaría yo Reinaldos de Montalbán si,
 en levantándome deste lecho, no me lo pagare, a pesar de todos sus
-encantamentos; y, por agora, tráiganme de yantar, que sé que es lo que más
+encantamientos; y, por agora, tráiganme de yantar, que sé que es lo que más
 me hará al caso, y quédese lo del vengarme a mi cargo.
 
 Hiciéronlo ansí: diéronle de comer, y quedóse otra vez dormido, y ellos,
@@ -3699,7 +3699,7 @@ preguntar Vivaldo que qué quería decir "caballeros andantes".
 historias de Ingalaterra, donde se tratan las famosas fazañas del rey
 Arturo, que continuamente en nuestro romance castellano llamamos el rey
 Artús, de quien es tradición antigua y común en todo aquel reino de la Gran
-Bretaña que este rey no murió, sino que, por arte de encantamento, se
+Bretaña que este rey no murió, sino que, por arte de encantamiento, se
 convirtió en cuervo, y que, andando los tiempos, ha de volver a reinar y a
 cobrar su reino y cetro; a cuya causa no se probará que desde aquel tiempo
 a éste haya ningún inglés muerto cuervo alguno? Pues en tiempo de este buen
@@ -4945,7 +4945,7 @@ tesoro para otros, y para nosotros sólo guarda las puñadas y los
 candilazos.
 
 — Así es —respondió don Quijote—, y no hay que hacer caso destas cosas de
-encantamentos, ni hay para qué tomar cólera ni enojo con ellas; que, como
+encantamientos, ni hay para qué tomar cólera ni enojo con ellas; que, como
 son invisibles y fantásticas, no hallaremos de quién vengarnos, aunque más
 lo procuremos. Levántate, Sancho, si puedes, y llama al alcaide desta
 fortaleza, y procura que se me dé un poco de aceite, vino, sal y romero
@@ -5179,7 +5179,7 @@ carne y hueso como nosotros; y todos, según los oí nombrar cuando me
 volteaban, tenían sus nombres: que el uno se llamaba Pedro Martínez, y el
 otro Tenorio Hernández, y el ventero oí que se llamaba Juan Palomeque el
 Zurdo. Así que, señor, el no poder saltar las bardas del corral, ni apearse
-del caballo, en ál estuvo que en encantamentos. Y lo que yo saco en limpio
+del caballo, en ál estuvo que en encantamientos. Y lo que yo saco en limpio
 de todo esto es que estas aventuras que andamos buscando, al cabo al cabo,
 nos han de traer a tantas desventuras que no sepamos cuál es nuestro pie
 derecho. Y lo que sería mejor y más acertado, según mi poco entendimiento,
@@ -5206,7 +5206,7 @@ vuestra merced dice.
 — Ésa es la pena que yo tengo y la que tú debes tener, Sancho —respondió don
 Quijote—; pero, de aquí adelante, yo procuraré haber a las manos alguna
 espada hecha por tal maestría, que al que la trujere consigo no le puedan
-hacer ningún género de encantamentos; y aun podría ser que me deparase la
+hacer ningún género de encantamientos; y aun podría ser que me deparase la
 ventura aquella de Amadís, cuando se llamaba el Caballero de la Ardiente
 Espada, que fue una de las mejores espadas que tuvo caballero en el mundo,
 porque, fuera que tenía la virtud dicha, cortaba como una navaja, y no
@@ -5238,7 +5238,7 @@ Volvió a mirarlo don Quijote, y vio que así era la verdad; y, alegrándose
 sobremanera, pensó, sin duda alguna, que eran dos ejércitos que venían a
 embestirse y a encontrarse en mitad de aquella espaciosa llanura; porque
 tenía a todas horas y momentos llena la fantasía de aquellas batallas,
-encantamentos, sucesos, desatinos, amores, desafíos, que en los libros de
+encantamientos, sucesos, desatinos, amores, desafíos, que en los libros de
 caballerías se cuentan, y todo cuanto hablaba, pensaba o hacía era
 encaminado a cosas semejantes. Y la polvareda que había visto la levantaban
 dos grandes manadas de ovejas y carneros que, por aquel mesmo camino, de
@@ -5346,7 +5346,7 @@ que su amo nombraba; y, como no descubría a ninguno, le dijo:
 
 — Señor, encomiendo al diablo hombre, ni gigante, ni caballero de cuantos
 vuestra merced dice parece por todo esto; a lo menos, yo no los veo; quizá
-todo debe ser encantamento, como las fantasmas de anoche.
+todo debe ser encantamiento, como las fantasmas de anoche.
 
 — ¿Cómo dices eso? —respondió don Quijote—. ¿No oyes el relinchar de los
 caballos, el tocar de los clarines, el ruido de los atambores?
@@ -6500,7 +6500,7 @@ diciendo: ''Éste es el Caballero del Sol'', o de la Sierpe, o de otra
 insignia alguna, debajo de la cual hubiere acabado grandes hazañas. ''Éste
 es —dirán— el que venció en singular batalla al gigantazo Brocabruno de la
 Gran Fuerza; el que desencantó al Gran Mameluco de Persia del largo
-encantamento en que había estado casi novecientos años''. Así que, de mano
+encantamiento en que había estado casi novecientos años''. Así que, de mano
 en mano, irán pregonando tus hechos, y luego, al alboroto de los muchachos
 y de la demás gente, se parará a las fenestras de su real palacio el rey de
 aquel reino, y así como vea al caballero, conociéndole por las armas o por
@@ -7908,7 +7908,7 @@ penitencia en la Peña Pobre, mudado su nombre en el de Beltenebros, nombre,
 por cierto, significativo y proprio para la vida que él de su voluntad
 había escogido. Ansí que, me es a mí más fácil imitarle en esto que no en
 hender gigantes, descabezar serpientes, matar endriagos, desbaratar
-ejércitos, fracasar armadas y deshacer encantamentos. Y, pues estos lugares
+ejércitos, fracasar armadas y deshacer encantamientos. Y, pues estos lugares
 son tan acomodados para semejantes efectos, no hay para qué se deje pasar
 la ocasión, que ahora con tanta comodidad me ofrece sus guedejas.
 
@@ -10960,7 +10960,7 @@ merced darme papilla, porque por Dios que no soy nada blanco. ¡Bueno es que
 quiera darme vuestra merced a entender que todo aquello que estos buenos
 libros dicen sea disparates y mentiras, estando impreso con licencia de los
 señores del Consejo Real, como si ellos fueran gente que habían de dejar
-imprimir tanta mentira junta, y tantas batallas y tantos encantamentos que
+imprimir tanta mentira junta, y tantas batallas y tantos encantamientos que
 quitan el juicio!
 
 — Ya os he dicho, amigo —replicó el cura—, que esto se hace para entretener
@@ -12381,7 +12381,7 @@ ver la batalla de su ayudador y de su contrario.
 Andaba Sancho buscando la cabeza del gigante por todo el suelo, y, como no
 la hallaba, dijo:
 
-— Ya yo sé que todo lo desta casa es encantamento; que la otra vez, en este
+— Ya yo sé que todo lo desta casa es encantamiento; que la otra vez, en este
 mesmo lugar donde ahora me hallo, me dieron muchos mojicones y porrazos,
 sin saber quién me los daba, y nunca pude ver a nadie; y ahora no parece
 por aquí esta cabeza que vi cortar por mis mismísimos ojos, y la sangre
@@ -12451,7 +12451,7 @@ pacífica en su reino, de darle el mejor condado que en él hubiese.
 Consolóse con esto Sancho, y aseguró a la princesa que tuviese por cierto
 que él había visto la cabeza del gigante, y que, por más señas, tenía una
 barba que le llegaba a la cintura; y que si no parecía, era porque todo
-cuanto en aquella casa pasaba era por vía de encantamento, como él lo había
+cuanto en aquella casa pasaba era por vía de encantamiento, como él lo había
 probado otra vez que había posado en ella. Dorotea dijo que así lo creía, y
 que no tuviese pena, que todo se haría bien y sucedería a pedir de boca.
 Sosegados todos, el cura quiso acabar de leer la novela, porque vio que
@@ -13023,7 +13023,7 @@ de admirar.
 
 — No me maravillaría de nada deso —replicó don Quijote—, porque, si bien te
 acuerdas, la otra vez que aquí estuvimos te dije yo que todo cuanto aquí
-sucedía eran cosas de encantamento, y no sería mucho que ahora fuese lo
+sucedía eran cosas de encantamiento, y no sería mucho que ahora fuese lo
 mesmo.
 
 — Todo lo creyera yo —respondió Sancho—, si también mi manteamiento fuera
@@ -13031,7 +13031,7 @@ cosa dese jaez, mas no lo fue, sino real y verdaderamente; y vi yo que el
 ventero que aquí está hoy día tenía del un cabo de la manta, y me empujaba
 hacia el cielo con mucho donaire y brío, y con tanta risa como fuerza; y
 donde interviene conocerse las personas, tengo para mí, aunque simple y
-pecador, que no hay encantamento alguno, sino mucho molimiento y mucha mala
+pecador, que no hay encantamiento alguno, sino mucho molimiento y mucha mala
 ventura.
 
 — Ahora bien, Dios lo remediará —dijo don Quijote—. Dame de vestir y déjame
@@ -15307,7 +15307,7 @@ alguno, puesto que de la paciencia y quietud de Rocinante bien se podía
 esperar que estaría sin moverse un siglo entero.
 
 En resolución, viéndose don Quijote atado, y que ya las damas se habían
-ido, se dio a imaginar que todo aquello se hacía por vía de encantamento,
+ido, se dio a imaginar que todo aquello se hacía por vía de encantamiento,
 como la vez pasada, cuando en aquel mesmo castillo le molió aquel moro
 encantado del arriero; y maldecía entre sí su poca discreción y discurso,
 pues, habiendo salido tan mal la vez primera de aquel castillo, se había
@@ -15321,7 +15321,7 @@ se moviese; y, aunque él quisiera sentarse y ponerse en la silla, no podía
 sino estar en pie, o arrancarse la mano.
 
 Allí fue el desear de la espada de Amadís, contra quien no tenía fuerza de
-encantamento alguno; allí fue el maldecir de su fortuna; allí fue el
+encantamiento alguno; allí fue el maldecir de su fortuna; allí fue el
 exagerar la falta que haría en el mundo su presencia el tiempo que allí
 estuviese encantado, que sin duda alguna se había creído que lo estaba;
 allí el acordarse de nuevo de su querida Dulcinea del Toboso; allí fue el
@@ -15705,7 +15705,7 @@ intención que la que vuestra merced dice, tan bacía es el yelmo de Malino
 como el jaez deste buen hombre albarda!
 
 — Haz lo que te mando —replicó don Quijote—, que no todas las cosas deste
-castillo han de ser guiadas por encantamento.
+castillo han de ser guiadas por encantamiento.
 
 Sancho fue a do estaba la bacía y la trujo; y, así como don Quijote la vio,
 la tomó en las manos y dijo:
@@ -15777,7 +15777,7 @@ y yo le damos la ventaja.
 las cosas que en este castillo, en dos veces que en él he alojado, me han
 sucedido, que no me atreva a decir afirmativamente ninguna cosa de lo que
 acerca de lo que en él se contiene se preguntare, porque imagino que cuanto
-en él se trata va por vía de encantamento. La primera vez me fatigó mucho
+en él se trata va por vía de encantamiento. La primera vez me fatigó mucho
 un moro encantado que en él hay, y a Sancho no le fue muy bien con otros
 sus secuaces; y anoche estuve colgado deste brazo casi dos horas, sin saber
 cómo ni cómo no vine a caer en aquella desgracia. Así que, ponerme yo agora
@@ -15786,7 +15786,7 @@ En lo que toca a lo que dicen que ésta es bacía, y no yelmo, ya yo tengo
 respondido; pero, en lo de declarar si ésa es albarda o jaez, no me atrevo
 a dar sentencia difinitiva: sólo lo dejo al buen parecer de vuestras
 mercedes. Quizá por no ser armados caballeros, como yo lo soy, no tendrán
-que ver con vuestras mercedes los encantamentos deste lugar, y tendrán los
+que ver con vuestras mercedes los encantamientos deste lugar, y tendrán los
 entendimientos libres, y podrán juzgar de las cosas deste castillo como
 ellas son real y verdaderamente, y no como a mí me parecían.
 
@@ -16167,7 +16167,7 @@ vuestro buen escudero ha dicho, porque quizá no las debe de decir sin
 ocasión, ni de su buen entendimiento y cristiana conciencia se puede
 sospechar que levante testimonio a nadie; y así, se ha de creer, sin poner
 duda en ello, que, como en este castillo, según vos, señor caballero,
-decís, todas las cosas van y suceden por modo de encantamento, podría ser,
+decís, todas las cosas van y suceden por modo de encantamiento, podría ser,
 digo, que Sancho hubiese visto por esta diabólica vía lo que él dice que
 vio, tan en ofensa de mi honestidad.
 
@@ -16189,7 +16189,7 @@ diciendo:
 
 — Agora acabarás de conocer, Sancho hijo, ser verdad lo que yo otras muchas
 veces te he dicho de que todas las cosas deste castillo son hechas por vía
-de encantamento.
+de encantamiento.
 
 — Así lo creo yo —dijo Sancho—, excepto aquello de la manta, que realmente
 sucedió por vía ordinaria.
@@ -16201,7 +16201,7 @@ venganza de tu agravio.
 Desearon saber todos qué era aquello de la manta, y el ventero lo contó,
 punto por punto: la volatería de Sancho Panza, de que no poco se rieron
 todos; y de que no menos se corriera Sancho, si de nuevo no le asegurara su
-amo que era encantamento; puesto que jamás llegó la sandez de Sancho a
+amo que era encantamiento; puesto que jamás llegó la sandez de Sancho a
 tanto, que creyese no ser verdad pura y averiguada, sin mezcla de engaño
 alguno, lo de haber sido manteado por personas de carne y hueso, y no por
 fantasmas soñadas ni imaginadas, como su señor lo creía y lo afirmaba.
@@ -16315,7 +16315,7 @@ confusión! Pero quizá la caballería y los encantos destos nuestros tiempos
 deben de seguir otro camino que siguieron los antiguos. Y también podría
 ser que, como yo soy nuevo caballero en el mundo, y el primero que ha
 resucitado el ya olvidado ejercicio de la caballería aventurera, también
-nuevamente se hayan inventado otros géneros de encantamentos y otros modos
+nuevamente se hayan inventado otros géneros de encantamientos y otros modos
 de llevar a los encantados. ¿Qué te parece desto, Sancho hijo?
 
 — No sé yo lo que me parece —respondió Sancho—, por no ser tan leído como
@@ -16495,7 +16495,7 @@ Y, volviéndose a mirar al cura, prosiguió diciendo:
 
 — ¡Ah señor cura, señor cura! ¿Pensaba vuestra merced que no le conozco, y
 pensará que yo no calo y adivino adónde se encaminan estos nuevos
-encantamentos? Pues sepa que le conozco, por más que se encubra el rostro,
+encantamientos? Pues sepa que le conozco, por más que se encubra el rostro,
 y sepa que le entiendo, por más que disimule sus embustes. En fin, donde
 reina la envidia no puede vivir la virtud, ni adonde hay escaseza la
 liberalidad. !Mal haya el diablo!; que, si por su reverencia no fuera, ésta
@@ -16815,7 +16815,7 @@ continua asistencia del cura y el barbero, que tenía por sospechosos, se
 llegó a la jaula donde iba su amo, y le dijo:
 
 — Señor, para descargo de mi conciencia, le quiero decir lo que pasa cerca
-de su encantamento; y es que aquestos dos que vienen aquí cubiertos los
+de su encantamiento; y es que aquestos dos que vienen aquí cubiertos los
 rostros son el cura de nuestro lugar y el barbero; y imagino han dado esta
 traza de llevalle desta manera, de pura envidia que tienen como vuestra
 merced se les adelanta en hacer famosos hechos. Presupuesta, pues, esta
@@ -16840,7 +16840,7 @@ dónde me viene este daño; porque si, por una parte, tú me dices que me
 acompañan el barbero y el cura de nuestro pueblo, y, por otra, yo me veo
 enjaulado, y sé de mí que fuerzas humanas, como no fueran sobrenaturales,
 no fueran bastantes para enjaularme, ¿qué quieres que diga o piense sino
-que la manera de mi encantamento excede a cuantas yo he leído en todas
+que la manera de mi encantamiento excede a cuantas yo he leído en todas
 las historias que tratan de caballeros andantes que han sido encantados?
 Ansí que, bien puedes darte paz y sosiego en esto de creer que son los que
 dices, porque así son ellos como yo soy turco. Y, en lo que toca a querer
@@ -16900,7 +16900,7 @@ tienen la gana que vuestra merced tiene y que bebe cuando se lo dan, y come
 cuando lo tiene, y responde a todo aquello que le preguntan.
 
 — Verdad dices, Sancho —respondió don Quijote—, pero ya te he dicho que hay
-muchas maneras de encantamentos, y podría ser que con el tiempo se hubiesen
+muchas maneras de encantamientos, y podría ser que con el tiempo se hubiesen
 mudado de unos en otros, y que agora se use que los encantados hagan todo
 lo que yo hago, aunque antes no lo hacían. De manera que contra el uso de
 los tiempos no hay que argüir ni de qué hacer consecuencias. Yo sé y tengo
@@ -16983,7 +16983,7 @@ entender que ha habido en el mundo aquella infinidad de Amadises, y aquella
 turbamulta de tanto famoso caballero, tanto emperador de Trapisonda, tanto
 Felixmarte de Hircania, tanto palafrén, tanta doncella andante, tantas
 sierpes, tantos endriagos, tantos gigantes, tantas inauditas aventuras,
-tanto género de encantamentos, tantas batallas, tantos desaforados
+tanto género de encantamientos, tantas batallas, tantos desaforados
 encuentros, tanta bizarría de trajes, tantas princesas enamoradas, tantos
 escuderos condes, tantos enanos graciosos, tanto billete, tanto requiebro,
 tantas mujeres valientes; y, finalmente, tantos y tan disparatados casos
@@ -18928,7 +18928,7 @@ dicho Sancho; y no se podía persuadir a que tal historia hubiese, pues aún
 no estaba enjuta en la cuchilla de su espada la sangre de los enemigos que
 había muerto, y ya querían que anduviesen en estampa sus altas caballerías.
 Con todo eso, imaginó que algún sabio, o ya amigo o enemigo, por arte de
-encantamento las habrá dado a la estampa: si amigo, para engrandecerlas y
+encantamiento las habrá dado a la estampa: si amigo, para engrandecerlas y
 levantarlas sobre las más señaladas de caballero andante; si enemigo, para
 aniquilarlas y ponerlas debajo de las más viles que de algún vil escudero
 se hubiesen escrito, puesto —decía entre sí— que nunca hazañas de escuderos
@@ -20874,7 +20874,7 @@ Paréceme que los veo andar por el Toboso hechos unos bausanes, buscando a
 mi señora Dulcinea, y, aunque la encuentren en mitad de la calle, no la
 conocerán más que a mi padre.
 
-— Quizá, Sancho —respondió don Quijote—, no se estenderá el encantamento a
+— Quizá, Sancho —respondió don Quijote—, no se estenderá el encantamiento a
 quitar el conocimiento de Dulcinea a los vencidos y presentados gigantes y
 caballeros; y, en uno o dos de los primeros que yo venza y le envíe,
 haremos la experiencia si la ven o no, mandándoles que vuelvan a darme
@@ -21488,7 +21488,7 @@ suelta. Y dijo:
 
 — Vuestra merced sí que es escudero fiel y legal, moliente y corriente,
 magnífico y grande, como lo muestra este banquete, que si no ha venido aquí
-por arte de encantamento, parécelo, a lo menos; y no como yo, mezquino y
+por arte de encantamiento, parécelo, a lo menos; y no como yo, mezquino y
 malaventurado, que sólo traigo en mis alforjas un poco de queso, tan duro
 que pueden descalabrar con ello a un gigante, a quien hacen compañía cuatro
 docenas de algarrobas y otras tantas de avellanas y nueces, mercedes a la
@@ -21960,7 +21960,7 @@ Espejos y su escudero
 En estremo contento, ufano y vanaglorioso iba don Quijote por haber
 alcanzado vitoria de tan valiente caballero como él se imaginaba que era el
 de los Espejos, de cuya caballeresca palabra esperaba saber si el
-encantamento de su señora pasaba adelante, pues era forzoso que el tal
+encantamiento de su señora pasaba adelante, pues era forzoso que el tal
 vencido caballero volviese, so pena de no serlo, a darle razón de lo que
 con ella le hubiese sucedido. Pero uno pensaba don Quijote y otro el de los
 Espejos, puesto que por entonces no era otro su pensamiento sino buscar
@@ -22067,7 +22067,7 @@ para tener invidia a la fama que yo por ellas he ganado?
 
 — Pues, ¿qué diremos, señor —respondió Sancho—, a esto de parecerse tanto
 aquel caballero, sea el que se fuere, al bachiller Carrasco, y su escudero
-a Tomé Cecial, mi compadre? Y si ello es encantamento, como vuestra merced
+a Tomé Cecial, mi compadre? Y si ello es encantamiento, como vuestra merced
 ha dicho, ¿no había en el mundo otros dos a quien se parecieran?
 
 — Todo es artificio y traza —respondió don Quijote— de los malignos magos
@@ -23153,7 +23153,7 @@ Camacho, no pareciéndole ser bien casarla con Basilio, que no tenía tantos
 bienes de fortuna como de naturaleza; pues si va a decir las verdades sin
 invidia, él es el más ágil mancebo que conocemos: gran tirador de barra,
 luchador estremado y gran jugador de pelota; corre como un gamo, salta más
-que una cabra y birla a los bolos como por encantamento; canta como una
+que una cabra y birla a los bolos como por encantamiento; canta como una
 calandria, y toca una guitarra, que la hace hablar, y, sobre todo, juega
 una espada como el más pintado.
 
@@ -23355,7 +23355,7 @@ por don Quijote, antes que le despertase, le dijo:
 
 — ¡Oh tú, bienaventurado sobre cuantos viven sobre la haz de la tierra, pues
 sin tener invidia ni ser invidiado, duermes con sosegado espíritu, ni te
-persiguen encantadores, ni sobresaltan encantamentos! Duerme, digo otra
+persiguen encantadores, ni sobresaltan encantamientos! Duerme, digo otra
 vez, y lo diré otras ciento, sin que te tengan en contina vigilia celos de
 tu dama, ni te desvelen pensamientos de pagar deudas que debas, ni de lo
 que has de hacer para comer otro día tú y tu pequeña y angustiada familia.
@@ -24390,7 +24390,7 @@ el lienzo y en las manos, era la señora Belerma, la cual con sus doncellas
 cuatro días en la semana hacían aquella procesión y cantaban, o, por mejor
 decir, lloraban endechas sobre el cuerpo y sobre el lastimado corazón de su
 primo; y que si me había parecido algo fea, o no tan hermosa como tenía la
-fama, era la causa las malas noches y peores días que en aquel encantamento
+fama, era la causa las malas noches y peores días que en aquel encantamiento
 pasaba, como lo podía ver en sus grandes ojeras y en su color quebradiza.
 ''Y no toma ocasión su amarillez y sus ojeras de estar con el mal mensil,
 ordinario en las mujeres, porque ha muchos meses, y aun años, que no le
@@ -24437,7 +24437,7 @@ cuenta, tres días he estado en aquellas partes remotas y escondidas a la
 vista nuestra.
 
 — Verdad debe de decir mi señor —dijo Sancho—, que, como todas las cosas que
-le han sucedido son por encantamento, quizá lo que a nosotros nos parece un
+le han sucedido son por encantamiento, quizá lo que a nosotros nos parece un
 hora, debe de parecer allá tres días con sus noches.
 
 — Así será —respondió don Quijote.
@@ -24565,7 +24565,7 @@ levantó dos varas de medir en el aire.
 
 — ¡Oh santo Dios! —dijo a este tiempo dando una gran voz Sancho—. ¿Es
 posible que tal hay en el mundo, y que tengan en él tanta fuerza los
-encantadores y encantamentos, que hayan trocado el buen juicio de mi señor
+encantadores y encantamientos, que hayan trocado el buen juicio de mi señor
 en una tan disparatada locura? ¡Oh señor, señor, por quien Dios es, que
 vuestra merced mire por sí y vuelva por su honra, y no dé crédito a esas
 vaciedades que le tienen menguado y descabalado el sentido!
@@ -26967,7 +26967,7 @@ dicho, que podría ser que yo tuviese alguna gracia déstas, no del no
 poder ser ferido, porque muchas veces la experiencia me ha mostrado que soy
 de carnes blandas y no nada impenetrables, ni la de no poder ser encantado,
 que ya me he visto metido en una jaula, donde todo el mundo no fuera
-poderoso a encerrarme, si no fuera a fuerzas de encantamentos; pero, pues
+poderoso a encerrarme, si no fuera a fuerzas de encantamientos; pero, pues
 de aquél me libré, quiero creer que no ha de haber otro alguno que me
 empezca; y así, viendo estos encantadores que con mi persona no pueden usar
 de sus malas mañas, vénganse en las cosas que más quiero, y quieren
@@ -27153,7 +27153,7 @@ ocho días, que aún no está en historia; conviene a saber: lo del encanto de
 mi señora doña Dulcinea, que le he dado a entender que está encantada, no
 siendo más verdad que por los cerros de Úbeda.
 
-Rogóle la duquesa que le contase aquel encantamento o burla, y Sancho se lo
+Rogóle la duquesa que le contase aquel encantamiento o burla, y Sancho se lo
 contó todo del mesmo modo que había pasado, de que no poco gusto recibieron
 los oyentes; y, prosiguiendo en su plática, dijo la duquesa:
 
@@ -27682,7 +27682,7 @@ donde estaba mi alma entretenida
 en formar ciertos rombos y caráteres,
 llegó la voz doliente de la bella
 y sin par Dulcinea del Toboso.
-Supe su encantamento y su desgracia,
+Supe su encantamiento y su desgracia,
 y su trasformación de gentil dama
 en rústica aldeana; condolíme,
 y, encerrando mi espíritu en el hueco
@@ -28058,7 +28058,7 @@ que el más cuitado pensamiento del orbe pueda haber pensado. Y primero
 quiere saber si está en este vuestro castillo el valeroso y jamás vencido
 caballero don Quijote de la Mancha, en cuya busca viene a pie y sin
 desayunarse desde el reino de Candaya hasta este vuestro estado, cosa que
-se puede y debe tener a milagro o a fuerza de encantamento. Ella queda a la
+se puede y debe tener a milagro o a fuerza de encantamiento. Ella queda a la
 puerta desta fortaleza o casa de campo, y no aguarda para entrar sino
 vuestro beneplácito. Dije.
 
@@ -28800,7 +28800,7 @@ Nuestro Señor o invocar los ángeles que me favorezcan.
 A lo que respondió Trifaldi:
 
 — Sancho, bien podéis encomendaros a Dios o a quien quisiéredes, que
-Malambruno, aunque es encantador, es cristiano, y hace sus encantamentos
+Malambruno, aunque es encantador, es cristiano, y hace sus encantamientos
 con mucha sagacidad y con mucho tiento, sin meterse con nadie.
 
 — ¡Ea, pues —dijo Sancho—, Dios me ayude y la Santísima Trinidad de Gaeta!
@@ -29053,7 +29053,7 @@ ladito, y la vi toda.
 que se mira.
 
 — Yo no sé esas miradas —replicó Sancho—: sólo sé que será bien que vuestra
-señoría entienda que, pues volábamos por encantamento, por encantamento
+señoría entienda que, pues volábamos por encantamiento, por encantamiento
 podía yo ver toda la tierra y todos los hombres por doquiera que los
 mirara; y si esto no se me cree, tampoco creerá vuestra merced cómo,
 descubriéndome por junto a las cejas, me vi tan junto al cielo que no había
@@ -31615,7 +31615,7 @@ verdad esto del gobierno de Sancho, y de que hay duquesa en el mundo que le
 envíe presentes y le escriba? Porque nosotros, aunque tocamos los presentes
 y hemos leído las cartas, no lo creemos, y pensamos que ésta es una de las
 cosas de don Quijote, nuestro compatrioto, que todas piensa que son hechas
-por encantamento; y así, estoy por decir que quiero tocar y palpar a
+por encantamiento; y así, estoy por decir que quiero tocar y palpar a
 vuestra merced, por ver si es embajador fantástico o hombre de carne y
 hueso.
 
@@ -31623,7 +31623,7 @@ hueso.
 verdadero, y que el señor Sancho Panza es gobernador efectivo, y que mis
 señores duque y duquesa pueden dar, y han dado, el tal gobierno; y que he
 oído decir que en él se porta valentísimamente el tal Sancho Panza; si en
-esto hay encantamento o no, vuestras mercedes lo disputen allá entre ellos,
+esto hay encantamiento o no, vuestras mercedes lo disputen allá entre ellos,
 que yo no sé otra cosa, para el juramento que hago, que es por vida de mis
 padres, que los tengo vivos y los amo y los quiero mucho.
 
@@ -32165,7 +32165,7 @@ corte; mírate en ello, y avísame de tu gusto, que yo procuraré honrarte en
 ella andando en coche.
 
 El cura, el barbero, el bachiller y aun el sacristán no pueden creer que
-eres gobernador, y dicen que todo es embeleco, o cosas de encantamento,
+eres gobernador, y dicen que todo es embeleco, o cosas de encantamiento,
 como son todas las de don Quijote tu amo; y dice Sansón que ha de ir a
 buscarte y a sacarte el gobierno de la cabeza, y a don Quijote la locura de
 los cascos; yo no hago sino reírme, y mirar mi sarta, y dar traza del
@@ -35585,7 +35585,7 @@ supiese quién era. Levantaron a don Quijote, descubriéronle el rostro y
 halláronle sin color y trasudando. Rocinante, de puro malparado, no se pudo
 mover por entonces. Sancho, todo triste, todo apesarado, no sabía qué
 decirse ni qué hacerse: parecíale que todo aquel suceso pasaba en sueños y
-que toda aquella máquina era cosa de encantamento. Veía a su señor rendido
+que toda aquella máquina era cosa de encantamiento. Veía a su señor rendido
 y obligado a no tomar armas en un año; imaginaba la luz de la gloria de sus
 hazañas escurecida, las esperanzas de sus nuevas promesas deshechas, como
 se deshace el humo con el viento. Temía si quedaría o no contrecho


### PR DESCRIPTION
`encantamento`: means nothing -> `encantamiento`: [RAE](https://dle.rae.es/encantamiento)